### PR TITLE
Added admb_args in call to mceval so ctl file name is passed

### DIFF
--- a/R/sample_admb.R
+++ b/R/sample_admb.R
@@ -431,7 +431,7 @@ sample_admb <- function(model, path=getwd(), iter=2000, init=NULL, chains=3, war
   write.table(unbounded, file='unbounded.csv', sep=",", col.names=FALSE, row.names=FALSE)
   if(mceval){
     if(verbose) message("Running -mceval on merged chains...")
-    system(paste(.update_model(model), "-mceval"), ignore.stdout=FALSE)
+    system(paste(.update_model(model), admb_args, "-mceval"), ignore.stdout=FALSE)
   }
   covar.est <- cov(unbounded)
   if(!skip_monitor){


### PR DESCRIPTION
To get `sample_nuts` to correctly run '-mceval' it seems to require 'admb_args'. In this case I have '-ind h1_1.00.ctl' when running 'jjms'.